### PR TITLE
BUGFIX/MINOR(replicator): Cleanup useless settings and use syslogtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@ An Ansible role for OpenIO replicator. Specifically, the responsibilities of thi
 
 | Variable   | Default | Comments (type)  |
 | :---       | :---    | :---             |
-| `openio_replicator_admin_bind_address` | `"{{ openio_replicator_bind_address }}"` | Address IP to use for admin |
-| `openio_replicator_admin_bind_port` | `6018` | Listening PORT for admin |
-| `openio_replicator_bind_address` | `openio_bind_address` | Address IP to use |
-| `openio_replicator_bind_interface` | `ansible_default_ipv4.alias` | Interface to use |
-| `openio_replicator_bind_port` | `6015` | Listening PORT |
 | `openio_replicator_consumer_queue` | `"oio-repli"` | Tube used in queue service |
 | `openio_replicator_consumer_target` | `"{{ openio_replicator_bind_address }}:6014"` | URL of queue service |
 | `openio_replicator_destination_ecd_url` | `""` | remote URL of ECD service |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ openio_replicator_bind_interface: "{{ ansible_default_ipv4.alias }}"
 openio_replicator_bind_address:
   "{{ openio_bind_address \
     | default(hostvars[inventory_hostname]['ansible_' + openio_replicator_bind_interface]['ipv4']['address']) }}"
-openio_replicator_bind_port: 6015
+
 openio_replicator_oioproxy_url: "http://{{ openio_replicator_bind_address }}:6006"
 openio_replicator_ecd_url: "{{ 'http://' ~ openio_replicator_bind_address ~ ':6017' \
   if groups.ecd is defined and groups.ecd \
@@ -28,6 +28,4 @@ openio_replicator_consumer_queue: "oio-repli"
 openio_replicator_workers: 1
 openio_replicator_log_level: INFO
 
-openio_replicator_admin_bind_address: "{{ openio_replicator_bind_address }}"
-openio_replicator_admin_bind_port: 6018
 ...

--- a/templates/replicator.conf.j2
+++ b/templates/replicator.conf.j2
@@ -29,12 +29,7 @@
     "queue": "{{ openio_replicator_consumer_queue }}"
   },
   "logs": {
-    "access": "/var/log/oio/sds/{{ openio_replicator_namespace }}/{{ openio_replicator_servicename }}/replicator.access",
-    "errors": "/var/log/oio/sds/{{ openio_replicator_namespace }}/{{ openio_replicator_servicename }}/replicator.log",
+    "syslogtag": "OIO,{{ openio_replicator_namespace }},replicator,{{ openio_replicator_serviceid }}",
     "level": "{{ openio_replicator_log_level }}"
-  },
-  "admin": {
-    "bind": "{{ openio_replicator_admin_bind_address }}",
-    "port": {{ openio_replicator_admin_bind_port }}
   }
 }


### PR DESCRIPTION
 ##### SUMMARY

- Remove deprecated settings
- Logs are now shipped by syslog

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION