### PR TITLE
BUGFIX/MINOR(replicator): Rechange log method to file

### DIFF
--- a/templates/replicator.conf.j2
+++ b/templates/replicator.conf.j2
@@ -29,7 +29,8 @@
     "queue": "{{ openio_replicator_consumer_queue }}"
   },
   "logs": {
-    "syslogtag": "OIO,{{ openio_replicator_namespace }},replicator,{{ openio_replicator_serviceid }}",
+    "access": "/var/log/oio/sds/{{ openio_replicator_namespace }}/{{ openio_replicator_servicename }}/replicator.access",
+    "errors": "/var/log/oio/sds/{{ openio_replicator_namespace }}/{{ openio_replicator_servicename }}/replicator.log",
     "level": "{{ openio_replicator_log_level }}"
   }
 }


### PR DESCRIPTION
 ##### SUMMARY

The syslog is never called in replicator.
 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
Tests with `logger` shows that the rsyslog rules are good