### PR TITLE
FEATURE(replicator): Allow disable in gridinit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,4 +28,6 @@ openio_replicator_consumer_queue: "oio-repli"
 openio_replicator_workers: 1
 openio_replicator_log_level: INFO
 
+openio_replicator_gridinit_start_at_boot: true
+openio_replicator_gridinit_enabled: true
 ...

--- a/templates/gridinit_replicator.conf.j2
+++ b/templates/gridinit_replicator.conf.j2
@@ -1,8 +1,8 @@
 # {{ ansible_managed }}
 [Service.{{ openio_replicator_namespace }}-{{ openio_replicator_servicename }}]
 command=java -jar {{ jar_path }} {{ openio_replicator_sysconfig_dir }}/{{ openio_replicator_servicename }}/replicator.conf
-enabled=true
-start_at_boot=true
+enabled={{ openio_replicator_gridinit_enabled }}
+start_at_boot={{ openio_replicator_gridinit_start_at_boot }}
 on_die=respawn
 group={{ openio_replicator_namespace }},replicator,{{ openio_replicator_serviceid }}
 uid=openio


### PR DESCRIPTION
 ##### SUMMARY

Allow disabled installation, for passive site

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
    replicator:
      children:
        backs: {}
      vars:
        openio_replicator_namespace: OPENIO2
        openio_replicator_gridinit_file_prefix: "OPENIO2-"
        openio_replicator_destination_namespace: "OPENIO"
        openio_replicator_destination_oioproxy_url: "http://{{ openio_bind_address }}:6006"
        openio_replicator_destination_ecd_url: "http://{{ openio_bind_address }}:6017"
        openio_replicator_gridinit_start_at_boot: false
        openio_replicator_gridinit_enabled: false
```