### PR TITLE
FEATURE(replicator): Allow to replicate with the same storage policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An Ansible role for OpenIO replicator. Specifically, the responsibilities of thi
 | `openio_replicator_namespace` | `OPENIO` | Namespace |
 | `openio_replicator_oioproxy_url` | `"http://{{ openio_replicator_bind_address }}:6006"` | URL of local oioproxy |
 | `openio_replicator_provision_only` | `false` | Provision only without restarting services |
+| `openio_replicator_same_object_policy` | `false` | To replicate with the same storage policy |
 | `openio_replicator_serviceid` | `"{{ 0 + openio_legacy_serviceid | d(0) | int }}"` | ID in gridinit |
 | `openio_replicator_workers` | `1` | Number of workers |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,4 +30,6 @@ openio_replicator_log_level: INFO
 
 openio_replicator_gridinit_start_at_boot: true
 openio_replicator_gridinit_enabled: true
+
+openio_replicator_same_object_policy: false
 ...

--- a/templates/replicator.conf.j2
+++ b/templates/replicator.conf.j2
@@ -2,6 +2,9 @@
 {% if openio_replicator_workers %}
   "workers": {{ openio_replicator_workers }},
 {% endif %}
+{% if openio_replicator_same_object_policy  %}
+  "sameObjectPolicy": true,
+{% endif %}
   "source": {
     "oio": {
       "proxy": {


### PR DESCRIPTION
 ##### SUMMARY

Add the `sameObjectPolicy`paramater.
When it's set to true, the replicator will keep the object policy.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION