### PR TITLE
FEATURE(replicator): Allow to compare the replicated objects with the same object version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ An Ansible role for OpenIO replicator. Specifically, the responsibilities of thi
 | `openio_replicator_oioproxy_url` | `"http://{{ openio_replicator_bind_address }}:6006"` | URL of local oioproxy |
 | `openio_replicator_provision_only` | `false` | Provision only without restarting services |
 | `openio_replicator_same_object_policy` | `false` | To replicate with the same storage policy |
+| `openio_replicator_compare_same_object_version` | `true` | To compare the replicated objects with the same object version |
 | `openio_replicator_serviceid` | `"{{ 0 + openio_legacy_serviceid | d(0) | int }}"` | ID in gridinit |
 | `openio_replicator_workers` | `1` | Number of workers |
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,4 +32,5 @@ openio_replicator_gridinit_start_at_boot: true
 openio_replicator_gridinit_enabled: true
 
 openio_replicator_same_object_policy: false
+openio_replicator_compare_same_object_version: true
 ...

--- a/templates/replicator.conf.j2
+++ b/templates/replicator.conf.j2
@@ -5,6 +5,9 @@
 {% if openio_replicator_same_object_policy  %}
   "sameObjectPolicy": true,
 {% endif %}
+{% if not openio_replicator_compare_same_object_version  %}
+  "compareSameObjectVersion": false,
+{% endif %}
   "source": {
     "oio": {
       "proxy": {


### PR DESCRIPTION
 ##### SUMMARY

Add the `compareSameObjectVersion` paramater.
When it's set to false, you can not use the versioning.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION