### PR TITLE
CHANGE(replicator): move variables from `vars` to `default`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
-# roles/replicator/defaults/main.yml
 ---
 openio_replicator_namespace: "{{ namespace | d(default_namespace) | d('OPENIO') }}"
 openio_replicator_serviceid: "{{ 0 + openio_legacy_serviceid | d(0) | int }}"
@@ -33,4 +32,11 @@ openio_replicator_gridinit_enabled: true
 
 openio_replicator_same_object_policy: false
 openio_replicator_compare_same_object_version: true
+
+openio_replicator_sysconfig_dir: "/etc/oio/sds/{{ openio_replicator_namespace }}"
+openio_replicator_servicename: "replicator-{{ openio_replicator_serviceid }}"
+
+openio_replicator_definition_file: >
+  "{{ openio_replicator_sysconfig_dir }}/
+  {{ openio_replicator_servicename }}/{{ openio_replicator_servicename }}.conf"
 ...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,2 @@
 ---
-openio_replicator_sysconfig_dir: "/etc/oio/sds/{{ openio_replicator_namespace }}"
-openio_replicator_servicename: "replicator-{{ openio_replicator_serviceid }}"
-
-openio_replicator_definition_file: >
-  "{{ openio_replicator_sysconfig_dir }}/
-  {{ openio_replicator_servicename }}/{{ openio_replicator_servicename }}.conf"
 ...


### PR DESCRIPTION
 ##### SUMMARY
in `vars` should only remain variables that must be fixed.
All the others must be set in `defaults` (almost all variables).

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION